### PR TITLE
Update allow-plant-curing to allow catmint

### DIFF
--- a/PipeLeaf/assets/pipeleaf/patches/allow-plant-curing.json
+++ b/PipeLeaf/assets/pipeleaf/patches/allow-plant-curing.json
@@ -5,7 +5,7 @@
     "file": "game:blocktypes/plant/flower",
     "path": "/combustiblePropsByType",
     "value": {
-      "@.*-(goldenpoppy|orangemallow|cornflower)-.*": {
+      "@.*-(catmint|goldenpoppy|orangemallow|cornflower)-.*": {
         "meltingPoint": 150,
         "meltingDuration": 8,
         "smeltedRatio": 1,


### PR DESCRIPTION
noticed this vanilla plant wasn't allowing curing - it seems to be omitted from the patch for allowed plants for fire-curing.